### PR TITLE
Added fix for api-version

### DIFF
--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="DiscordProjectSettings">
-    <option name="show" value="ASK" />
-    <option name="description" value="" />
-  </component>
-</project>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ I got inspired by the [BoatInertia](https://github.com/danvanbueren/BoatInertia/
 - Enjoy
 
 ### Tested Versions
-- 1.20.1
+- 1.20.2
 
 ## Engines
 You just hold the crafted engine in your hand while steering a boat and you go way faster than without an engine.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ I got inspired by the [BoatInertia](https://github.com/danvanbueren/BoatInertia/
 - Enjoy
 
 ### Tested Versions
-- 1.20.2
+- 1.20.1-1.20.2
 
 ## Engines
 You just hold the crafted engine in your hand while steering a boat and you go way faster than without an engine.

--- a/SpeedyBoats.iml
+++ b/SpeedyBoats.iml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+        </autoDetectTypes>
+        <projectReimportVersion>1</projectReimportVersion>
+      </configuration>
+    </facet>
+  </component>
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
@@ -10,7 +20,7 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/Downloads/spigot-api-1.20.1-R0.1-20230614.100042-3-shaded.jar!/" />
+          <root url="jar://$USER_HOME$/Downloads/spigot-api-1.20.4-R0.1-20231212.204618-11-shaded.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,6 +1,7 @@
 main: de.sivery.speedyboats.SpeedyBoats
 name: SpeedyBoats
 version: '1.1'
+api-version: '1.20'
 description: Give your boats a little extra SPEEED
 author: Sivery
 website: github.com/siveryt/speedyboats


### PR DESCRIPTION
Rebuilt against the 1.20.4

Here is my log on the error when running on 1.20.2 Server.  I resolved by adding in the api-version as seen in request.  Love the work you do man!

[09:38:14] [Server thread/WARN]: [org.bukkit.craftbukkit.v1_20_R2.legacy.CraftLegacy] Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
[09:38:18] [Server thread/WARN]: Legacy plugin SpeedyBoats v1.1 does not specify an api-version.
[09:38:18] [Server thread/ERROR]: Fatal error trying to convert SpeedyBoats v1.1:de/sivery/speedyboats/SpeedyBoats.class
org.bukkit.plugin.AuthorNagException: No legacy enum constant for POPPED_CHORUS_FRUIT. Did you forget to define a modern (1.13+) api-version in your plugin.yml?
	at org.bukkit.craftbukkit.v1_20_R2.util.Commodore$1$1.visitFieldInsn(Commodore.java:363) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at org.objectweb.asm.ClassReader.readCode(ClassReader.java:2445) ~[asm-9.5.jar:9.5]
	at org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1514) ~[asm-9.5.jar:9.5]
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:744) ~[asm-9.5.jar:9.5]
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:424) ~[asm-9.5.jar:9.5]
	at org.bukkit.craftbukkit.v1_20_R2.util.Commodore.convert(Commodore.java:176) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at org.bukkit.craftbukkit.v1_20_R2.util.CraftMagicNumbers.processClass(CraftMagicNumbers.java:410) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at org.bukkit.plugin.java.PluginClassLoader.findClass(PluginClassLoader.java:223) ~[purpur-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:587) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:171) ~[purpur-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:166) ~[purpur-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
	at java.lang.Class.forName0(Native Method) ~[?:?]
	at java.lang.Class.forName(Class.java:467) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:80) ~[purpur-api-1.20.2-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:123) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:36) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at org.bukkit.craftbukkit.v1_20_R2.CraftServer.loadPlugins(CraftServer.java:528) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:310) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1102) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:320) ~[purpur-1.20.2.jar:git-Purpur-2095]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]